### PR TITLE
hexpansion fp-lib-table reference fix

### DIFF
--- a/hexpansion/fp-lib-table
+++ b/hexpansion/fp-lib-table
@@ -1,4 +1,4 @@
 (fp_lib_table
   (version 7)
-  (lib (name "tildagon")(type "KiCad")(uri "${KIPRJMOD}/../tildagon-base/tildagon.kicad_sym")(options "")(descr ""))
+  (lib (name "tildagon")(type "KiCad")(uri "${KIPRJMOD}/../tildagon-base/tildagon.pretty")(options "")(descr ""))
 )


### PR DESCRIPTION
Looks like the footprint and symbols libraries got mixed up at some point?